### PR TITLE
Improved Appearance of Line Numbers

### DIFF
--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -72,7 +72,8 @@ public class STTextViewController: NSViewController, STTextViewDelegate {
         rulerView = STLineNumberRulerView(textView: textView, scrollView: scrollView)
         rulerView.backgroundColor = theme.background
         rulerView.textColor = .systemGray
-        rulerView.separatorColor = theme.invisibles
+//        rulerView.separatorColor = theme.invisibles
+        rulerView.drawSeparator = false
         rulerView.baselineOffset = baselineOffset
 
         scrollView.verticalRulerView = rulerView

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -75,6 +75,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate {
 //        rulerView.separatorColor = theme.invisibles
         rulerView.drawSeparator = false
         rulerView.baselineOffset = baselineOffset
+        rulerView.font = NSFont.monospacedDigitSystemFont(ofSize: 9.5, weight: .regular)
 
         scrollView.verticalRulerView = rulerView
         scrollView.rulersVisible = true


### PR DESCRIPTION
This PR improves the overall appearance of the line numbers in the gutter of the editor.

## Related Issue
- #58

Before
<img width="565" alt="image" src="https://user-images.githubusercontent.com/806104/193641292-bdb92424-8d27-4559-b352-88b2105ba6f4.png">

Target
<img width="514" alt="image" src="https://user-images.githubusercontent.com/806104/193641489-a219c824-a2d7-42b5-86a7-f40abcaca39a.png">


After
<img width="603" alt="image" src="https://user-images.githubusercontent.com/806104/193641366-ba265b38-a74b-48d9-bada-113484d8823d.png">

It is not perfect though, it needs decreased tracking and narrower character width. This is the code I have added to produce this:
```swift
rulerView.font = NSFont.monospacedDigitSystemFont(ofSize: 9.5, weight: .regular)
```

It also uses character variants here such as the open "4" (you'll see in the target it is open, and in my version it is closed).

If anyone knows of a way to improve this let me know, otherwise we can merge this for the time being until we find a better solution.